### PR TITLE
Fix: Corrige o cálculo do valor intrínseco para `g` decimal

### DIFF
--- a/tests/test_graham.py
+++ b/tests/test_graham.py
@@ -14,3 +14,8 @@ class TestGrahamFormula(unittest.TestCase):
     def test_valor_intrinseco_selic_zero(self):
         valor = calcular_valor_intrinseco(10.0, 5.0, 0.0)
         self.assertEqual(valor, 0.0)
+
+    def test_valor_intrinseco_com_g_decimal(self):
+        # Teste com taxa de crescimento em decimal
+        valor = calcular_valor_intrinseco(lpa=5.0, g=0.06, selic=10.0)
+        self.assertAlmostEqual(valor, 45.1, places=1)

--- a/utils/graham.py
+++ b/utils/graham.py
@@ -6,7 +6,12 @@ def calcular_valor_intrinseco(lpa: float, g: float, selic: float) -> float:
         return 0.0
 
     try:
-        valor_intrinseco = (lpa * (8.5 + 2 * g) * 4.4) / selic
+        growth_rate = g
+        # Se a taxa de crescimento `g` for um decimal, converte para porcentagem
+        if abs(g) < 1:
+            growth_rate = g * 100
+
+        valor_intrinseco = (lpa * (8.5 + 2 * growth_rate) * 4.4) / selic
         return round(valor_intrinseco, 2)
     except Exception as e:
         raise ValueError(f"Erro ao calcular valor intrínseco: {e}") from e


### PR DESCRIPTION
A função `calcular_valor_intrinseco` em `utils/graham.py` não lidava corretamente com a taxa de crescimento (`g`) quando fornecida como um valor decimal (ex: 0.06 em vez de 6). Isso resultava em um cálculo incorreto do valor intrínseco.

Esta correção adiciona uma verificação para converter `g` em uma porcentagem (multiplicando por 100) se for um valor decimal (abs(g) < 1), garantindo que a fórmula de Graham funcione como esperado em ambos os cenários.

Um novo teste foi adicionado em `tests/test_graham.py` para validar o comportamento com `g` decimal, que agora passa com sucesso.

## Summary by Sourcery

Ensure calculation of intrinsic value handles growth rates provided as decimals by converting them to percentages and validate this scenario with a new test

Bug Fixes:
- Correct intrinsic value calculation when growth rate is given as a decimal

Tests:
- Add test for decimal growth rate input in calcular_valor_intrinseco