### PR TITLE
Fix: Corrige o cálculo do valor intrínseco para `g` decimal

### DIFF
--- a/tests/test_graham.py
+++ b/tests/test_graham.py
@@ -14,3 +14,33 @@ class TestGrahamFormula(unittest.TestCase):
     def test_valor_intrinseco_selic_zero(self):
         valor = calcular_valor_intrinseco(10.0, 5.0, 0.0)
         self.assertEqual(valor, 0.0)
+
+    def test_valor_intrinseco_com_g_decimal(self):
+        # Teste com taxa de crescimento em decimal
+        valor = calcular_valor_intrinseco(lpa=5.0, g=0.06, selic=10.0)
+        self.assertAlmostEqual(valor, 45.1, places=1)
+
+    def test_valor_intrinseco_com_g_negativo(self):
+        # Teste com taxa de crescimento negativa
+        valor = calcular_valor_intrinseco(lpa=5.0, g=-5.0, selic=10.0)
+        self.assertAlmostEqual(valor, -3.3, places=1)
+
+    def test_valor_intrinseco_com_g_negativo_decimal(self):
+        # Teste com taxa de crescimento negativa em decimal
+        valor = calcular_valor_intrinseco(lpa=5.0, g=-0.05, selic=10.0)
+        self.assertAlmostEqual(valor, -3.3, places=1)
+
+    def test_valor_intrinseco_com_g_limite_inferior(self):
+        # Teste com g no limite inferior da conversão decimal (-0.99)
+        valor = calcular_valor_intrinseco(lpa=1.0, g=-0.99, selic=10.0)
+        self.assertAlmostEqual(valor, -83.38, places=2)
+
+    def test_valor_intrinseco_com_g_limite_superior(self):
+        # Teste com g no limite superior da conversão decimal (0.99)
+        valor = calcular_valor_intrinseco(lpa=1.0, g=0.99, selic=10.0)
+        self.assertAlmostEqual(valor, 90.86, places=2)
+
+    def test_valor_intrinseco_com_g_fora_limite(self):
+        # Teste com g fora do limite da conversão decimal (1.0)
+        valor = calcular_valor_intrinseco(lpa=1.0, g=1.0, selic=10.0)
+        self.assertAlmostEqual(valor, 4.62, places=2)

--- a/utils/graham.py
+++ b/utils/graham.py
@@ -6,7 +6,10 @@ def calcular_valor_intrinseco(lpa: float, g: float, selic: float) -> float:
         return 0.0
 
     try:
-        valor_intrinseco = (lpa * (8.5 + 2 * g) * 4.4) / selic
+        # Se a taxa de crescimento `g` for um decimal, converte para porcentagem
+        growth_rate = g * 100 if abs(g) < 1 else g
+
+        valor_intrinseco = (lpa * (8.5 + 2 * growth_rate) * 4.4) / selic
         return round(valor_intrinseco, 2)
     except Exception as e:
         raise ValueError(f"Erro ao calcular valor intrínseco: {e}") from e


### PR DESCRIPTION
A função `calcular_valor_intrinseco` em `utils/graham.py` não lidava corretamente com a taxa de crescimento (`g`) quando fornecida como um valor decimal (ex: 0.06 em vez de 6). Isso resultava em um cálculo incorreto do valor intrínseco.

Esta correção adiciona uma verificação para converter `g` em uma porcentagem (multiplicando por 100) se for um valor decimal (abs(g) < 1), garantindo que a fórmula de Graham funcione como esperado em ambos os cenários.

Um novo teste foi adicionado em `tests/test_graham.py` para validar o comportamento com `g` decimal, que agora passa com sucesso.

## Summary by Sourcery

Fix the calculation of intrinsic value when the growth rate `g` is provided as a decimal and add tests covering decimal, negative, and boundary growth scenarios

Bug Fixes:
- Convert `g` to percentage when its absolute value is less than 1 to correct the intrinsic value formula

Tests:
- Add tests for decimal growth rates, negative rates, boundary conversion limits, and out-of-range cases to validate the updated behavior